### PR TITLE
Fixes hero width

### DIFF
--- a/source/partials/homepage/_hero.slim
+++ b/source/partials/homepage/_hero.slim
@@ -1,17 +1,19 @@
 .u-smallMargin
 .ContentFormatter.ContentFormatter--centerHorizontally
-  img.u-onlySmall(
-    src="#{image_path('homepage/hero-mobile.png')}"
-    srcset="#{image_path('homepage/hero-mobile.png')} 320w, #{image_path('homepage/hero-mobile@2x.png')} 640w"
-    sizes="100vw"
-    alt="Another galaxy"
-  )
-  img.u-exceptSmall(
-    src="#{image_path('homepage/hero-image@1x.png')}"
-    srcset="#{image_path('homepage/hero-image@1x.png')} 1441w, #{image_path('homepage/hero-image@2x.png')} 2882w, #{image_path('homepage/hero-image@3x.png')} 4223w"
-    sizes="(min-width: 1280px) 80vw, 100vw"
-    alt="Another galaxy"
-  )
+  .u-onlySmall
+    img.RatioEnforcer(
+      src="#{image_path('homepage/hero-mobile.png')}"
+      srcset="#{image_path('homepage/hero-mobile.png')} 320w, #{image_path('homepage/hero-mobile@2x.png')} 640w"
+      sizes="100vw"
+      alt="Another galaxy"
+    )
+  .u-exceptSmall
+    img.RatioEnforcer(
+      src="#{image_path('homepage/hero-image@1x.png')}"
+      srcset="#{image_path('homepage/hero-image@1x.png')} 1441w, #{image_path('homepage/hero-image@2x.png')} 2882w, #{image_path('homepage/hero-image@3x.png')} 4223w"
+      sizes="(min-width: 1280px) 80vw, 100vw"
+      alt="Another galaxy"
+    )
 .u-smallMargin
 .GridCell.GridCell--alignCenter.u-defaultThenDoubleLargeMargin
   .GridCell-content

--- a/source/partials/work/_hero.slim
+++ b/source/partials/work/_hero.slim
@@ -7,7 +7,7 @@
         br
         ' handcrafted
         span.Heading-highlight Work
-      img(
+      img.RatioEnforcer(
         src="#{image_path('work/origami.png')}"
         srcset="#{image_path('work/origami.png')} 481w, #{image_path('work/origami@2x.png')} 962w"
         sizes="(min-width: 650px) 480px, 220px"


### PR DESCRIPTION
On browsers with fixed scrollbars (which take up space), the hero images were adding a small horizontal scroll on smaller resolutions (<1100px)

PS: RatioEnforcer conflicts with u-onlySmall and u-exceptSmall, since both set the `display` property, so I had to separate them