### PR TITLE
Corrects the nav

### DIFF
--- a/source/partials/_nav.slim
+++ b/source/partials/_nav.slim
@@ -15,7 +15,7 @@ header#main-nav.Nav.Nav--topPositioned class="#{current_page.data.nav_class}"
       span.Burger-line
       span.Burger-line
 
-  nav aria-label='Main navigation'
+  nav.Nav-itemsWrapper aria-label='Main navigation'
     ul.Nav-items
       = nav_item('Work', '/work')
       = nav_item('Company', '/company')


### PR DESCRIPTION
In order for the navbar in mobile to work correctly with the new
structure, we need a class on the actual `nav` element, so it can by
hidden in those resolutions.