### PR TITLE
Loads Typekit asynchronously

### DIFF
--- a/source/layouts/layout.slim
+++ b/source/layouts/layout.slim
@@ -40,9 +40,6 @@ html.Theme itemscope='' itemtype='http://schema.org/WebPage' lang=data.site.lang
     = stylesheet_link_tag 'all'
     = yield_content :stylesheets
 
-    script src="//use.typekit.net/wbx6iwp.js"
-    javascript:
-      try{Typekit.load();}catch(e){}
     = favicon_tag 'favicon.ico'
     = favicon_tag 'favicon.ico', rel: 'apple-touch-icon', type: 'image/x-icon'
 
@@ -56,6 +53,9 @@ html.Theme itemscope='' itemtype='http://schema.org/WebPage' lang=data.site.lang
     main role='main'
       = yield
 
+    script async="true" src="//use.typekit.net/wbx6iwp.js"
+    javascript:
+      try{Typekit.load();}catch(e){}
     = javascript_include_tag 'all'
     - if build?
       = javascript_include_tag 'segment'


### PR DESCRIPTION
Improves perceived speed by loading typekit asynchronously.
Must be used with *Font Face Observer* and requires https://github.com/subvisual/blue/pull/94

Resources:
http://help.typekit.com/customer/portal/articles/6852-Controlling-the-Flash-of-Unstyled-Text-or-FOUT-using-Font-Events