### PR TITLE
Safari (mac and iOS) fixes 

### DIFF
--- a/source/partials/case-studies/_creators-school-link.slim
+++ b/source/partials/case-studies/_creators-school-link.slim
@@ -3,7 +3,7 @@
     .u-defaultThenLargeMargin
     .HorizontalGrid.HorizontalGrid--withGutters.u-defaultThenLargeMargin
       .HorizontalGrid-cell
-        .ContentFormatter.ContentFormatter--center.u-smallThenNoneMargin
+        .ContentFormatter.ContentFormatter--centerHorizontally.u-smallThenNoneMargin
           img(
             src="#{image_path('case-studies/creators-school/logo.png')}"
             srcset="#{image_path('case-studies/creators-school/logo.png')} 200w, #{image_path('case-studies/creators-school/logo@2x.png')} 400w"

--- a/source/partials/case-studies/_easy-money-link.slim
+++ b/source/partials/case-studies/_easy-money-link.slim
@@ -3,7 +3,7 @@
     .u-defaultThenLargeMargin
     .HorizontalGrid.HorizontalGrid--withGutters.u-defaultThenLargeMargin
       .HorizontalGrid-cell
-        .ContentFormatter.ContentFormatter--center.u-smallThenNoneMargin
+        .ContentFormatter.ContentFormatter--centerHorizontally.u-smallThenNoneMargin
           img(
             src="#{image_path('case-studies/easy-money/logo.png')}"
             srcset="#{image_path('case-studies/easy-money/logo.png')} 200w, #{image_path('case-studies/easy-money/logo@2x.png')} 400w"

--- a/source/partials/case-studies/creators-school/2015/_gallery.slim
+++ b/source/partials/case-studies/creators-school/2015/_gallery.slim
@@ -1,6 +1,6 @@
 .Panel
   .u-defaultThenLargeMargin
-  .ContentFormatter.ContentFormatter--center
+  .ContentFormatter.ContentFormatter--centerHorizontally
     .cs-Gallery
       - %w(america html jobs programadores zuckerberg ironman trabalho ruby).each do |name|
         .cs-Gallery-cell

--- a/source/stylesheets/case-studies/creators-school/_ratio-enforcer.scss
+++ b/source/stylesheets/case-studies/creators-school/_ratio-enforcer.scss
@@ -1,4 +1,5 @@
 .RatioEnforcer.RatioEnforcer--csPicture {
+  min-height: 120px;
   max-width: 120px;
 }
 

--- a/source/stylesheets/components/_clients_grid.scss
+++ b/source/stylesheets/components/_clients_grid.scss
@@ -1,4 +1,4 @@
-.ClientsGrid {
+  .ClientsGrid {
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
@@ -9,9 +9,7 @@
 }
 
 .ClientsGrid-cell {
-  flex-grow: 0;
-  flex-shrink: 0;
-  flex-basis: auto;
+  flex: 1 0 100px; //this is workaround for safari and iOS, https://bugs.webkit.org/show_bug.cgi?id=136041
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -24,6 +22,7 @@
 
 @include media('>=500px') {
   .ClientsGrid-cell {
+    flex: 1 0 25%; //this is workaround for safari and iOS, https://bugs.webkit.org/show_bug.cgi?id=136041
     min-width: 25%;
   }
 }
@@ -42,6 +41,7 @@
 
 @include media('>=1250px') {
   .ClientsGrid-cell {
+    flex: 1 0 200px; //this is workaround for safari and iOS, https://bugs.webkit.org/show_bug.cgi?id=136041
     min-width: 200px;
   }
 }

--- a/source/stylesheets/components/_panel.scss
+++ b/source/stylesheets/components/_panel.scss
@@ -283,7 +283,7 @@
     position: absolute;
     top: 0;
     left: 0;
-    z-index: $Theme-layer-overlay + 1;
+    z-index: $Theme-layer-stickyElement;
 
     display: flex;
     align-items: center;


### PR DESCRIPTION
- Pictures on CS case study now showing;
- CS case study gallery with correct height;
- Nav overlay on easy.money and CS case studyes withow text from background;
- Case studies links on work page with correct height; 
- Clients grid now wraps correctly;

![screen shot 2015-08-07 at 14 53 25](https://cloud.githubusercontent.com/assets/4236592/9137214/245cd580-3d14-11e5-8fe2-4ccefba3d4e9.png)
![screen shot 2015-08-07 at 12 27 51](https://cloud.githubusercontent.com/assets/4236592/9134972/15a0372a-3d01-11e5-8bfd-50543cfeb1ed.png)
![screen shot 2015-08-07 at 12 28 16](https://cloud.githubusercontent.com/assets/4236592/9134971/159d5492-3d01-11e5-8262-7233f14550d1.png)
![11844118_980760341986497_1738691308_n](https://cloud.githubusercontent.com/assets/4236592/9134974/1862a448-3d01-11e5-88b0-fb18ed626936.jpg)
![screen shot 2015-08-07 at 12 50 51](https://cloud.githubusercontent.com/assets/4236592/9135217/fc30b8b2-3d02-11e5-988e-c1a6e486991d.png)
