### PR TITLE
Fixes styleguide

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -49,7 +49,7 @@ namespace :styleguide do
   end
 
   def compile_stylesheets
-    `bundle exec sass --load-path vendor/blue/stylesheets --load-path vendor/blue/images --load-path bower_components --require susy --require font-awesome-sass source/stylesheets/all.scss`
+    `bundle exec sass --load-path vendor/blue/stylesheets --load-path vendor/blue/images --load-path bower_components --require susy source/stylesheets/all.scss`
   end
 
   def styleguide_command(style_source, output_folder, watch)

--- a/source/stylesheets/components/_atom.scss
+++ b/source/stylesheets/components/_atom.scss
@@ -146,6 +146,7 @@ $Atom-electrons: (
   $startRotation: map-get($values, 'startRotation');
 
   // animate each electron to rotate around the orbit
+  // styleguide:ignore:start
   @keyframes rotate-#{$name} {
     0% {
       transform: rotate($startRotation + 0deg)   translate(-$Atom-size * 0.5) rotate(-$startRotation - 0deg);
@@ -155,6 +156,7 @@ $Atom-electrons: (
       transform: rotate($startRotation + 360deg) translate(-$Atom-size * 0.5) rotate(-$startRotation - 360deg);
     }
   }
+  // styleguide:ignore:end
 
   .Atom-orbit--#{$name} .Atom-electron {
     animation: rotate-#{$name} infinite linear;


### PR DESCRIPTION
Why:

* The styleguide was not showing the styles

This change addresses the need by:

* Stop requiring the font-awesome-sass, which we have stopped using a
while ago
* Ignoring some of the SASS special sintax in animations, which the
linter seems to dislike