### PR TITLE
μoptimizing <head>

### DIFF
--- a/source/layouts/layout.slim
+++ b/source/layouts/layout.slim
@@ -3,8 +3,14 @@ html.Theme itemscope='' itemtype='http://schema.org/WebPage' lang=data.site.lang
   head
     meta charset='utf-8'
     meta content='IE=edge,chrome=1' http-equiv='X-UA-Compatible'
+    // Mobile Specific Metas
+    meta name='viewport' content='width=device-width, initial-scale=1'
+
+    = stylesheet_link_tag 'all'
+    = yield_content :stylesheets
 
     title=page_title
+
     meta name='description' content=page_description
     meta name='robots' content='index,follow'
 
@@ -29,16 +35,9 @@ html.Theme itemscope='' itemtype='http://schema.org/WebPage' lang=data.site.lang
     meta itemprop='description' content=page_description
     meta itemprop='image' content=data.site.image
 
-    // Mobile Specific Metas
-    meta name='viewport' content='width=device-width, initial-scale=1'
-
     // Preferred URL (rel="canonical")
     - if current_page.data.preferred_url
       link rel='canonical' href=current_page.data.preferred_url
-
-    = yield_content :prefetch
-    = stylesheet_link_tag 'all'
-    = yield_content :stylesheets
 
     = favicon_tag 'favicon.ico'
     = favicon_tag 'favicon.ico', rel: 'apple-touch-icon', type: 'image/x-icon'


### PR DESCRIPTION
As explained [here](http://www.nateberkopec.com/2015/10/21/hacking-head-tags-for-speed-and-profit.html?utm_source=Ruby+Performance+Newsletter&utm_campaign=916fde13a7-Tags_for_Fun_and_Profit10_21_2015&utm_medium=email&utm_term=0_840412962b-916fde13a7-129585657):

> if you put the viewport meta tag after your stylesheets, you will cause a layout reflow for the entire document, slowing down rendering. Don't do that. Keep your viewport tags at the top, right after your character encoding. In addition, putting a viewport tag at the bottom of the head will almost certainly cause a "flash of unstyled content" as the CSS is first loaded in the default viewport, then re-rendered in your specified viewport.

I also took the chance to do 2 other things:

* Also moved stylesheets up in. The rest are just meta-tags for search engines
and twitter/facebook integration. Stylesheets are more urgent than those when
loading a page. This probably won't actually improve speed in any perceivable
way, but since we have so many meta tags, it feels right.
* There was a `yield_content :prefetch` which was apparently not being used
anymore. @azevedo-252, can you confirm that?