### PR TITLE
Fix Creators School plug for Easy Money case study.

### DIFF
--- a/source/partials/case-studies/creators-school/_plug.slim
+++ b/source/partials/case-studies/creators-school/_plug.slim
@@ -1,12 +1,11 @@
-.Panel.Panel--easymoneyGradient
-  .Panel.Panel--easymoneyMapaMundi.cs-Panel--easymoneyPlug
-    .Panel-backgroundImage
-    .Panel-content
-      .GridCell.GridCell--alignCenter
-        .GridCell-content
-          .ContentFormatter.ContentFormatter--centerHorizontally
-            h1.Heading.Heading--brandLarge.u-defaultMargin
-              span.Heading-light> Crafting
-              span.Heading-highlight
-                | easy.money
-            = link_to "See Making Of easy.money", '/case-studies/easy-money', class: 'ButtonPrimary'
+.Panel.Panel--easymoneyGradient.Panel--easymoneyMapaMundi.cs-Panel--easymoneyPlug
+  .Panel-backgroundImage
+  .Panel-content
+    .GridCell.GridCell--alignCenter
+      .GridCell-content
+        .ContentFormatter.ContentFormatter--centerHorizontally
+          h1.Heading.Heading--brandLarge.u-defaultMargin
+            span.Heading-light> Crafting
+            span.Heading-highlight
+              | easy.money
+          = link_to "See Making Of easy.money", '/case-studies/easy-money', class: 'ButtonPrimary'


### PR DESCRIPTION
Why:

* The Creators School plug for easy.money case study was not displaying the background correctly on Firefox.

This change addresses the need by:

* Removing the extra `Panel` component from the root of the template.
* Adding the `Panel--easymoneyGradient` modifier to the existing `Panel`.