### PR TITLE
Fixes homepage SVGs

### DIFF
--- a/source/images/homepage/hero.svg
+++ b/source/images/homepage/hero.svg
@@ -1,4 +1,4 @@
-<svg id="HomepageHero" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 1440 540">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 1440 540">
   <title>
     Subvisual Planets
   </title>

--- a/source/images/homepage/tools.svg
+++ b/source/images/homepage/tools.svg
@@ -1,4 +1,4 @@
-<svg id="LogoTools" class="LogoTools" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 301 301" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg class="LogoTools" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 301 301" xmlns:xlink="http://www.w3.org/1999/xlink">
   <title>
     tools
   </title>

--- a/source/images/homepage/transparency.svg
+++ b/source/images/homepage/transparency.svg
@@ -1,4 +1,4 @@
-<svg id="LogoTransparency" class="LogoTransparency" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 302 302" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg class="LogoTransparency" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 302 302" xmlns:xlink="http://www.w3.org/1999/xlink">
   <title>
     transparency
   </title>
@@ -42,9 +42,9 @@
             <path d="M83.06 309.144v-334.47"/>
           </g>
           <g stroke="url(#transparency-linearGradient-6)" stroke-width="2" mask="url(#transparency-mask-5)">
-            <path class="LogoTransparency-piece TransparencyIcon-pieceTop" d="M82 209.092l68.182 40.91 68.182-40.91v-36.364l-68.182 40.91L82 172.728v36.363z"/>
-            <path class="LogoTransparency-piece TransparencyIcon-pieceTop" d="M82 90.91L150.182 50l68.182 40.91v36.363l-68.182-40.91L82 127.273V90.91z"/>
-            <path class="LogoTransparency-piece TransparencyIcon-pieceTop" d="M82 90.91l68.182 40.908 68.182 40.91v36.363l-68.182-40.907L82 127.273V90.91z"/>
+            <path class="LogoTransparency-piece" d="M82 209.092l68.182 40.91 68.182-40.91v-36.364l-68.182 40.91L82 172.728v36.363z"/>
+            <path class="LogoTransparency-piece" d="M82 90.91L150.182 50l68.182 40.91v36.363l-68.182-40.91L82 127.273V90.91z"/>
+            <path class="LogoTransparency-piece" d="M82 90.91l68.182 40.908 68.182 40.91v36.363l-68.182-40.907L82 127.273V90.91z"/>
           </g>
         </g>
       </g>

--- a/source/index.slim
+++ b/source/index.slim
@@ -18,9 +18,9 @@ nav_logo_class: 'is-animated'
 = partial 'newsletter'
 = partial 'footer'
 
-javascript:
-  window.onload = function() {
-    var svg = document.querySelector('#HomepageHero');
-    window.homepage.animateLines(svg);
-    /* window.homepage.animatePlanets(svg); */
-  };
+- content_for :javascripts
+  javascript:
+    $('#HomepageHero').load(function() {
+      var svg = $('#HomepageHero').contents().find('svg')[0];
+      window.homepage.animateLines(svg);
+    })

--- a/source/javascripts/homepage/_hero_parallax.es6
+++ b/source/javascripts/homepage/_hero_parallax.es6
@@ -1,6 +1,6 @@
-$(function() {
+$('#HomepageHero').load(function() {
   var translations = {};
-  var svg = document.getElementById('HomepageHero');
+  var svg = $('#HomepageHero').contents();
 
   function translateLayer(id, hDistance, vDistance, factor) {
     var hDistanceScaled = hDistance / factor;
@@ -23,7 +23,7 @@ $(function() {
       onUpdate: function() {
         var currentX = x + stepX * counter.value;
         var currentY = y + stepY * counter.value;
-        svg.getElementById(id).setAttribute('transform', 'translate(' + currentX + ', ' + currentY + ')');
+        svg.find(id)[0].setAttribute('transform', 'translate(' + currentX + ', ' + currentY + ')');
         translations[id] = { x: currentX, y: currentY };
       }
     });
@@ -35,13 +35,13 @@ $(function() {
     var hDistance = (window.innerWidth/2) - amountMovedX;
     var vDistance = (window.innerHeight/2) - amountMovedY;
 
-    translateLayer("lines", hDistance, vDistance, 85);
-    translateLayer("distance-3x", hDistance, vDistance, 45);
-    translateLayer("distance-2x", hDistance, vDistance, -65);
-    translateLayer("distance-1x", hDistance, vDistance, 85);
+    translateLayer("#lines", hDistance, vDistance, 85);
+    translateLayer("#distance-3x", hDistance, vDistance, 45);
+    translateLayer("#distance-2x", hDistance, vDistance, -65);
+    translateLayer("#distance-1x", hDistance, vDistance, 85);
   }
 
   if (svg) {
-    svg.addEventListener("mousemove", parallax, false);
+    $(svg.find('svg'))[0].addEventListener("mousemove", parallax, false);
   }
 });

--- a/source/javascripts/homepage/_logo_tools.es6
+++ b/source/javascripts/homepage/_logo_tools.es6
@@ -1,5 +1,7 @@
-$(function() {
+$('#LogoTools').load(function() {
   var isOverLogo = false;
+  var svg = $('#LogoTools').contents();
+  var svgName = svg.find('.Logo-name');
 
   function pathLength() {
     return this.getTotalLength();
@@ -25,7 +27,7 @@ $(function() {
   }
 
   function animation(tool, options) {
-    var $tool = $(tool);
+    var $tool = svg.find(tool);
     if ($tool.data('animating')) {
       return;
     }
@@ -37,19 +39,19 @@ $(function() {
     var direction = options.direction || 1;
     var angle = options.angle || 10;
 
-    TweenLite.set(tool, { rotation: 0, transformOrigin: 'center' });
-    TweenLite.to(tool, 0.2, { rotation:  angle * direction, delay: delay });
-    TweenLite.to(tool, 0.4, { rotation: -angle * direction, delay: delay + 0.2 });
-    TweenLite.to(tool, 0.2, { rotation:      0,             delay: delay + 0.6, onComplete: callback });
+    TweenLite.set($tool, { rotation: 0, transformOrigin: 'center' });
+    TweenLite.to($tool, 0.2, { rotation:  angle * direction, delay: delay });
+    TweenLite.to($tool, 0.4, { rotation: -angle * direction, delay: delay + 0.2 });
+    TweenLite.to($tool, 0.2, { rotation:      0,             delay: delay + 0.6, onComplete: callback });
   }
 
   function nameAnimation() {
-    TweenLite.set('.Logo-name', { fillOpacity: 0, x: 100 });
-    TweenLite.to('.Logo-name', 0.8, { x: 0, delay: 0.5 });
-    TweenLite.to('.Logo-name', 0.8, { fillOpacity: 1, delay: 0.5 });
+    TweenLite.set(svgName, { fillOpacity: 0, x: 100 });
+    TweenLite.to(svgName, 0.8, { x: 0, delay: 0.5 });
+    TweenLite.to(svgName, 0.8, { fillOpacity: 1, delay: 0.5 });
   }
 
-  $('.LogoTools-tool').on('mouseenter', function() {
+  $(svg.find('.LogoTools-tool')).on('mouseenter', function() {
     animateSingleTool('#' + this.id);
   });
 

--- a/source/javascripts/homepage/_logo_transparency.es6
+++ b/source/javascripts/homepage/_logo_transparency.es6
@@ -1,13 +1,15 @@
-$(function() {
+$('#LogoTransparency').load(function() {
   var animating = false;
+
+  var svg = $('#LogoTransparency').contents();
 
   function onAnimationFinished() {
     animating = false;
   }
 
   function logoSetup() {
-    $('.LogoTransparency-piece').each(function() {
-      TweenLite.set('.LogoTransparency-piece', { strokeDasharray: this.getTotalLength(), strokeDashoffset: this.getTotalLength()  });
+    svg.find('.LogoTransparency-piece').each(function() {
+      TweenLite.set(svg.find('.LogoTransparency-piece'), { strokeDasharray: this.getTotalLength(), strokeDashoffset: this.getTotalLength()  });
     });
   }
 
@@ -17,8 +19,8 @@ $(function() {
     }
     animating = true;
     logoSetup();
-    $('.LogoTransparency-piece').each(function() {
-      TweenLite.to('.LogoTransparency-piece', 0.8, { strokeDashoffset: 0, onComplete: onAnimationFinished });
+    svg.find('.LogoTransparency-piece').each(function() {
+      TweenLite.to(svg.find('.LogoTransparency-piece'), 0.8, { strokeDashoffset: 0, onComplete: onAnimationFinished });
     });
   }
 

--- a/source/partials/homepage/_hero.slim
+++ b/source/partials/homepage/_hero.slim
@@ -8,14 +8,7 @@ h1.u-visuallyHidden We are Subvisual
     alt="Another galaxy"
   )
 .u-exceptSmall
-  = partial 'homepage/hero.svg'
-  /.u-exceptSmall
-  /  img.RatioEnforcer(
-  /    src="#{image_path('homepage/hero-image@1x.png')}"
-  /    srcset="#{image_path('homepage/hero-image@1x.png')} 1441w, #{image_path('homepage/hero-image@2x.png')} 2882w, #{image_path('homepage/hero-image@3x.png')} 4223w"
-  /    sizes="(min-width: 1280px) 80vw, 100vw"
-  /    alt="Another galaxy"
-  /  )
+  object#HomepageHero.HoverAnimation data="/images/homepage/hero.svg" type="image/svg+xml"
 .u-smallMargin
 .GridCell.GridCell--alignCenter.u-defaultThenDoubleLargeMargin
   .GridCell-content

--- a/source/partials/homepage/_services.slim
+++ b/source/partials/homepage/_services.slim
@@ -4,7 +4,7 @@
     .HorizontalGrid-cell
       .ContentFormatter.ContentFormatter--centerHorizontally
         .RatioEnforcer.RatioEnforcer--homepageIcons
-          = partial 'homepage/tools.svg'
+          object#LogoTools.HoverAnimation type="image/svg+xml" data="#{image_path('homepage/tools.svg')}"
     .HorizontalGrid-cell
       .u-smallThenNoneMargin
       .Heading.u-xSmallThenSmallMargin

--- a/source/partials/homepage/_values.slim
+++ b/source/partials/homepage/_values.slim
@@ -4,7 +4,7 @@
     .HorizontalGrid-cell
       .ContentFormatter.ContentFormatter--centerHorizontally
         .RatioEnforcer.RatioEnforcer--homepageIcons
-          = partial 'homepage/transparency.svg'
+          object#LogoTransparency.HoverAnimation type="image/svg+xml" data="#{image_path('homepage/transparency.svg')}"
     .HorizontalGrid-cell
       .u-smallThenNoneMargin
       .Heading.u-xSmallThenSmallMargin

--- a/source/stylesheets/components/_base.scss
+++ b/source/stylesheets/components/_base.scss
@@ -11,6 +11,7 @@
 @import 'divider';
 @import 'error_page';
 @import 'hire_us_grid';
+@import 'hover_animation';
 @import 'input_text';
 @import 'newsletter';
 @import 'numbered_steps';

--- a/source/stylesheets/components/_hover_animation.scss
+++ b/source/stylesheets/components/_hover_animation.scss
@@ -1,0 +1,15 @@
+// HoverAnimation
+//
+// Reacts to mouse events, allowing hover animations to execute
+// This was added due to pointer-events being disabled by default for object elements.
+// We needed a way to enable them back without breaking existing objects.
+//
+// <div class="HoverAnimation">
+//   Animated content
+// </div>
+//
+// Styleguide 5.17
+
+.HoverAnimation {
+  pointer-events: all;
+}


### PR DESCRIPTION
Why:

We were having weird problems with SVGs on Firefox. This could be anything
from a small typo in our code to a bug in Firefox itself. After hours of
debugging, we decided to move the SVGs to object elements, which seems to work
fine as well. There are extra requests being made now, but at least it's
working

This change addresses the need by:

* Moving all SVGs in the homepage to an `object` tag, instead of having them inline
* Refactor the JS code for the animations to interact with the contents of the object, instead of directly in the DOM