### PR TITLE
Hide hellobar on small devices

### DIFF
--- a/source/stylesheets/all.scss
+++ b/source/stylesheets/all.scss
@@ -4,3 +4,4 @@
 @import 'blue';
 @import 'utilities/base';
 @import 'components/base';
+@import 'vendor/base';

--- a/source/stylesheets/vendor/_base.scss
+++ b/source/stylesheets/vendor/_base.scss
@@ -1,0 +1,1 @@
+@import 'hellobar';

--- a/source/stylesheets/vendor/_hellobar.scss
+++ b/source/stylesheets/vendor/_hellobar.scss
@@ -1,0 +1,3 @@
+@include media('<=700px') {
+  .HB-Slider { display: none !important; }
+}


### PR DESCRIPTION
Why:

The pop-up is really annoying on mobile devices. This hides it.