### PR TITLE
Fix team member picture

### DIFF
--- a/source/stylesheets/components/_team_member.scss
+++ b/source/stylesheets/components/_team_member.scss
@@ -44,6 +44,7 @@ $TeamMember-max-width-small: 200px;
 .TeamMember-picture {
   width: 100%;
   max-width: $TeamMember-max-width-small;
+  max-height: $TeamMember-max-width-small;
   margin-bottom: $Theme-spacing-small;
 
   @include media('>=700px') {


### PR DESCRIPTION
Why:

* Team member photos are being rendered as 200x400, causing the images
to stretch.

![screen shot 2016-01-22 at 02 20 45](https://cloud.githubusercontent.com/assets/1141870/12500963/ee0c2f56-c0af-11e5-9db3-284ff246129d.png)

This change addresses the error by:

* Limiting the height of the picture to keep it square.