### PR TITLE
Fix iOS issues with the hire us form

### DIFF
--- a/source/stylesheets/components/_hire_us_grid.scss
+++ b/source/stylesheets/components/_hire_us_grid.scss
@@ -23,10 +23,6 @@
   padding-right: $Theme-spacing-small;
 }
 
-.HireUsGrid-greetings {
-  flex: 1;
-}
-
 .HireUsGrid-form {
   flex: 2;
 
@@ -58,5 +54,9 @@
   .HireUsGrid-form {
     margin-top: 0;
     margin-left: $Theme-spacing-large;
+  }
+
+  .HireUsGrid-greetings {
+    flex: 1;
   }
 }

--- a/source/stylesheets/components/_radio.scss
+++ b/source/stylesheets/components/_radio.scss
@@ -25,6 +25,8 @@ $Radio-input-size: 25px;
   width: $Radio-input-size;
   height: $Radio-input-size;
 
+  border: 0;
+
   cursor: pointer;
   outline: 0;
 


### PR DESCRIPTION
Remove extra border in radio buttons on iOS

    Why:

    * We are styling radio buttons ourselves, on the `::before` pseudo element, so
      any extra style should be remove. Apparently there was an extra square border
      around our round radio button.

    This change addresses the need by:

    * Forcing the border on the actual input to be invisible

Fix issue with hire us form overflowing

    Why:

    * In Safari on small dimensions (and by extension iOS), the hire us form was
      overflowing to the next panel. This was happening due to an issue with how
      Safari uses flex, when compared to webkit.

    This change addresses the need by:

    * Only setting the `flex-grow` to 1 when the direction of flex is row, which is
      really the only place we need it and does not mess up with Safari