### PR TITLE
Fix project setup script

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -1,14 +1,12 @@
+#!/usr/bin/env bash
+
 if ! hash bundle 2>/dev/null; then
   gem install bundler
 fi
 
-if ! hash bower 2>/dev/null; then
-  npm install bower
-fi
-
-(bundle check &>/dev/null) || bundle install
-bower install
 npm install
+$(npm bin)/bower install
+(bundle check &>/dev/null) || bundle install
 
 git submodule init
 git submodule update

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "We are subvisual and this is our website.",
   "main": "gulpfile.js",
   "dependencies": {
+    "bower": "^1.7.9"
   },
   "devDependencies": {
     "sc5-styleguide": "^0.3.16"


### PR DESCRIPTION
Why:

* It does not specify which executable should run the script;
* It is using NPM to install bower manually instead of using a package
  manifest file;
* It is installing Bower without the global option, but assuming that
  the Bower executable will be available globally;
* It is installing Node dependencies after Bower dependencies.

These changes address the issues by:

* Refactoring the setup script;
* Adding Bower as a dependency to the package manifest file.