### PR TITLE
Replace links to HelloHired.com

### DIFF
--- a/data/site.yml
+++ b/data/site.yml
@@ -5,7 +5,7 @@ human_url: 'subvisual.co'
 name: 'Subvisual Website'
 description: 'Since 2011, Subvisual has helped companies transform ideas into successful products. We are a small, powerful team of professionals who understand how to create, build, and grow digital products.'
 title: 'Subvisual - Handcrafters of digital experiences'
-hiring_url: 'https://www.hellohired.com/subvisual'
+hiring_url: 'mailto:contact@subvisual.co'
 
 # Optional
 logo_image_name: ''


### PR DESCRIPTION
Why:

* HelloHired.com is no more.

This change addresses the need by:

* Refactoring the site configuration to replace links to hellohired.com
  with links to send us an e-mail.