### PR TITLE
Tuning

### DIFF
--- a/source/layouts/layout.slim
+++ b/source/layouts/layout.slim
@@ -54,7 +54,7 @@ html.Theme itemscope='' itemtype='http://schema.org/WebPage' lang=data.site.lang
 
     script src="//use.typekit.net/wbx6iwp.js"
     javascript:
-      try{Typekit.load();}catch(e){}
+      try{Typekit.load({ async: true });catch(e){}
     = javascript_include_tag 'all'
     = yield_content :javascripts
 

--- a/source/stylesheets/components/_technologies_grid.scss
+++ b/source/stylesheets/components/_technologies_grid.scss
@@ -36,6 +36,7 @@ $TechnologiesGrid-secondaryTechonolgy-color: #e0edf3;
 
 .TechnologiesGrid-primaryTechonolgy {
   display: flex;
+  color: $TechnologiesGrid-primaryTechonolgy-color;
 
   &:nth-child(odd) {
     padding-right: $Theme-spacing-default;
@@ -55,6 +56,7 @@ $TechnologiesGrid-secondaryTechonolgy-color: #e0edf3;
 
 .TechnologiesGrid-secondaryTechonolgy {
   display: none;
+  color: $TechnologiesGrid-secondaryTechonolgy-color;
 
   @include media('>=desktop') {
     display: flex;
@@ -83,12 +85,4 @@ $TechnologiesGrid-secondaryTechonolgy-color: #e0edf3;
   @include media('>=desktop') {
     height: 100px;
   }
-}
-
-.TechnologiesGrid-primaryTechonolgy {
-  color: $TechnologiesGrid-primaryTechonolgy-color;
-}
-
-.TechnologiesGrid-secondaryTechonolgy {
-  color: $TechnologiesGrid-secondaryTechonolgy-color;
 }


### PR DESCRIPTION
Why:

* We have duplicated CSS selectors
* We're loading Typekit in a synchronous way; according to
[this](http://blog.typekit.com/2015/08/04/new-embed-code-for-asynchronous-font-loading/)
we should do that if we don't want to block rendering of the page while
fonts are loading.

This change addresses the need by:

* Setting the `async` option of the embed code to true
* Merging duplicate selectors