### PR TITLE
Support more browsers

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -29,7 +29,7 @@ set :images_dir, 'images'
 set :partials_dir, 'partials'
 
 activate :autoprefixer do |config|
-  config.browsers = ['ie >= 11']
+  config.browsers = ['ie >= 11', 'last 2 versions']
 end
 
 activate :directory_indexes

--- a/source/stylesheets/components/_case_study.scss
+++ b/source/stylesheets/components/_case_study.scss
@@ -57,6 +57,7 @@ $CaseStudy-image-offset: $Theme-spacing-small;
 }
 
 .CaseStudy-image {
+  width: 100%;
   max-width: 100%;
   max-height: 100%;
 

--- a/source/stylesheets/components/_contacts.scss
+++ b/source/stylesheets/components/_contacts.scss
@@ -43,8 +43,10 @@
 }
 
 .Contacts-image {
-  max-height: 100%;
+  width: 100%;
   max-width: 100%;
+  max-height: 100%;
+
   box-shadow: 0 20px 60px 0 rgba(#000, 0.25);
 }
 


### PR DESCRIPTION
Using BrowserStack we noticed that our landing page didn't look right in
many browsers. The main reason for that is we were only using
auto-prefixer for ie, while Firefox and Chrome still needs prefixing for
rules like `column-count`.

Another common issue is images taking more space than they are supposed
to. That was solved by limiting them to their parents with `width:
100%`. There was already a `max-width` in place, but it was not having
any effect.