### PR TITLE
Update footer links

### DIFF
--- a/source/partials/_footer.slim
+++ b/source/partials/_footer.slim
@@ -19,7 +19,6 @@ footer
         .u-xSmallMargin
         ul.SitemapTopic-links
           li = link_to 'History', '/company#history', class: 'SitemapTopic-link'
-          li = link_to 'Values', '/company#values', class: 'SitemapTopic-link'
           li = link_to 'Team', '/company#team', class: 'SitemapTopic-link'
           li = link_to 'Join Us', '/company/join-us', class: 'SitemapTopic-link'
 
@@ -29,10 +28,11 @@ footer
           | Community
         .u-xSmallMargin
         ul.SitemapTopic-links
-          li = link_to 'Creators Schools', '/community#creatorsschool', class: 'SitemapTopic-link'
-          li = link_to 'RubyConf Portugal', '/community#rubyconfpt', class: 'SitemapTopic-link'
-          li = link_to 'BragaRB', '/community#bragarb', class: 'SitemapTopic-link'
-          li = link_to 'BragaJS', '/community#bragajs', class: 'SitemapTopic-link'
+          li = link_to 'Mirror Conf', 'http://www.mirrorconf.com/', target: :_blank, rel: 'noopener', class: 'SitemapTopic-link'
+          li = link_to 'RubyConf Portugal', 'http://rubyconf.pt/', target: :_blank, rel: 'noopener', class: 'SitemapTopic-link'
+          li = link_to 'Braga.Design', 'https://www.meetup.com/bragadesign/', target: :_blank, rel: 'noopener', class: 'SitemapTopic-link'
+          li = link_to 'Braga.JS', 'https://www.meetup.com/bragajs/', target: :_blank, rel: 'noopener', class: 'SitemapTopic-link'
+          li = link_to 'Braga.Product', 'https://www.meetup.com/Braga-Product/', target: :_blank, rel: 'noopener', class: 'SitemapTopic-link'
 
     .HorizontalGrid-cell
       .SitemapTopic
@@ -41,11 +41,11 @@ footer
         .u-xSmallMargin
         ul.SitemapTopic-links
           li = link_to 'Blog', '/blog', class: 'SitemapTopic-link'
-          li = link_to 'Github', 'https://github.com/subvisual', target: :blank, class: 'SitemapTopic-link'
-          li = link_to 'Dribbble', 'https://dribbble.com/subvisual', target: :blank, class: 'SitemapTopic-link'
-          li = link_to 'Twitter', 'https://twitter.com/subvisual', target: :blank, class: 'SitemapTopic-link'
-          li = link_to 'Facebook', 'https://www.facebook.com/subvisual.co', target: :blank, class: 'SitemapTopic-link'
-          li = link_to 'Instagram', 'https://www.instagram.com/wearesubvisual/', target: :blank, class: 'SitemapTopic-link'
+          li = link_to 'Github', 'https://github.com/subvisual', target: :_blank, rel: 'noopener', class: 'SitemapTopic-link'
+          li = link_to 'Dribbble', 'https://dribbble.com/subvisual', target: :_blank, rel: 'noopener', class: 'SitemapTopic-link'
+          li = link_to 'Twitter', 'https://twitter.com/subvisual', target: :_blank, rel: 'noopener', class: 'SitemapTopic-link'
+          li = link_to 'Facebook', 'https://www.facebook.com/subvisual.co', target: :_blank, rel: 'noopener', class: 'SitemapTopic-link'
+          li = link_to 'Instagram', 'https://www.instagram.com/wearesubvisual/', target: :_blank, rel: 'noopener', class: 'SitemapTopic-link'
 
   .Footer
     .Footer-credits


### PR DESCRIPTION
Why:

* The footer links are kind of outdated:
  - The company values section was removed;
  - RubyConf section in the community page refers to RubyConf 2015 and
    we're doing a gap year;
  - BragaRB is dead;
  - We're missing links for MirrorConf, Braga.Design and Braga.Product.

This change addresses the need by:

* Removing the company values, RubyConf and BragaRB links;
* Adding links for Mirror Conf, Braga.Design and Braga.Product.