### PR TITLE
Refactor nginx configs

### DIFF
--- a/nginx/blog.subvisual.co.conf
+++ b/nginx/blog.subvisual.co.conf
@@ -1,0 +1,26 @@
+#
+# rails upstream
+#
+upstream blog-subvisual-co {
+  server unix:///apps/blog.subvisual.co/shared/sockets/puma.sock;
+}
+
+#
+# blog subdomain - redirects to subvisual.co/blog
+#
+server {
+  listen 80;
+  listen 443 ssl;
+  server_name blog.subvisual.co www.blog.subvisual.co;
+  return 301 https://subvisual.co/blog$request_uri;
+
+  ssl_certificate     /etc/nginx/ssl/subvisual.co-2016/SSL.crt;
+  ssl_certificate_key /etc/nginx/ssl/subvisual.co-2016/server.key;
+  ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+  ssl_prefer_server_ciphers on;
+  ssl_session_cache shared:SSL:10m;
+  ssl_ciphers 'EECDH+AESGCM:EDH+AESGCM:ECDHE-RSA-AES128-GCM-SHA256:AES256+EECDH:DHE-RSA-AES128-GCM-SHA256:AES256+EDH:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA:ECDHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256:DHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES256-GCM-SHA384:AES128-GCM-SHA256:AES256-SHA256:AES128-SHA256:AES256-SHA:AES128-SHA:DES-CBC3-SHA:HIGH:!aNULL:!eNULL:!EXPORT:!DES:!MD5:!PSK:!RC4';
+  ssl_dhparam /etc/nginx/ssl/dhsecure.pem;
+  add_header Strict-Transport-Security "max-age=31536000; includeSubdomains;";
+}
+

--- a/nginx/groupbuddies.com.conf
+++ b/nginx/groupbuddies.com.conf
@@ -1,0 +1,37 @@
+#
+# main domain
+#
+server {
+  listen 80;
+  listen 443 ssl;
+  server_name groupbuddies.com www.groupbuddies.com;
+  return 301 https://subvisual.co$request_uri;
+
+  ssl_certificate     /etc/nginx/ssl/groupbuddies.com/SSL.crt;
+  ssl_certificate_key /etc/nginx/ssl/groupbuddies.com/server.key;
+  ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+  ssl_prefer_server_ciphers on;
+  ssl_session_cache shared:SSL:10m;
+  ssl_ciphers 'EECDH+AESGCM:EDH+AESGCM:ECDHE-RSA-AES128-GCM-SHA256:AES256+EECDH:DHE-RSA-AES128-GCM-SHA256:AES256+EDH:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA:ECDHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256:DHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES256-GCM-SHA384:AES128-GCM-SHA256:AES256-SHA256:AES128-SHA256:AES256-SHA:AES128-SHA:DES-CBC3-SHA:HIGH:!aNULL:!eNULL:!EXPORT:!DES:!MD5:!PSK:!RC4';
+  ssl_dhparam /etc/nginx/ssl/dhsecure.pem;
+  add_header Strict-Transport-Security "max-age=31536000; includeSubdomains;";
+}
+
+#
+# blog
+#
+server {
+  listen 80;
+  listen 443 ssl;
+  server_name blog.groupbuddies.com www.blog.groupbuddies.com;
+  return 301 https://subvisual.co/blog$request_uri;
+
+  ssl_certificate     /etc/nginx/ssl/groupbuddies.com/SSL.crt;
+  ssl_certificate_key /etc/nginx/ssl/groupbuddies.com/server.key;
+  ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+  ssl_prefer_server_ciphers on;
+  ssl_session_cache shared:SSL:10m;
+  ssl_ciphers 'EECDH+AESGCM:EDH+AESGCM:ECDHE-RSA-AES128-GCM-SHA256:AES256+EECDH:DHE-RSA-AES128-GCM-SHA256:AES256+EDH:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA:ECDHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256:DHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES256-GCM-SHA384:AES128-GCM-SHA256:AES256-SHA256:AES128-SHA256:AES256-SHA:AES128-SHA:DES-CBC3-SHA:HIGH:!aNULL:!eNULL:!EXPORT:!DES:!MD5:!PSK:!RC4';
+  ssl_dhparam /etc/nginx/ssl/dhsecure.pem;
+  add_header Strict-Transport-Security "max-age=31536000; includeSubdomains;";
+}

--- a/nginx/subvisual.co.conf
+++ b/nginx/subvisual.co.conf
@@ -1,5 +1,10 @@
+#
+# main server
+#
 server {
-  listen 443; server_name subvisual.co;
+  listen 443 ssl;
+  server_name subvisual.co;
+
   root /apps/subvisual.co/current;
 
   error_page 404 = /404/;
@@ -12,9 +17,6 @@ server {
     auth_basic off;
   }
 
-  location ^~ /newsletter/nginx.conf {
-    return 404;
-  }
   location ^~ /nginx.production.conf {
     return 404;
   }
@@ -52,12 +54,6 @@ server {
     proxy_pass http://blog-subvisual-co;
   }
 
-  location ^~ /newsletter {
-    alias /apps/newsletter.subvisual.co/;
-    access_log /apps/newsletter.subvisual.co/log/nginx.out;
-    error_log  /apps/newsletter.subvisual.co/log/nginx.err;
-  }
-
   location / {
     index index.html;
   }
@@ -67,7 +63,6 @@ server {
     add_header Cache-Control public;
   }
 
-  ssl on;
   ssl_certificate     /etc/nginx/ssl/subvisual.co-2016/SSL.crt;
   ssl_certificate_key /etc/nginx/ssl/subvisual.co-2016/server.key;
   ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
@@ -78,39 +73,42 @@ server {
   add_header Strict-Transport-Security "max-age=31536000; includeSubdomains;";
 }
 
-# www redirect
+#
+# http redirect
+#
+server {
+  listen 80;
+  server_name subvisual.co;
+  return 301 https://subvisual.co$request_uri;
+
+  ssl_certificate     /etc/nginx/ssl/subvisual.co-2016/SSL.crt;
+  ssl_certificate_key /etc/nginx/ssl/subvisual.co-2016/server.key;
+  ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+  ssl_prefer_server_ciphers on;
+  ssl_session_cache shared:SSL:10m;
+  ssl_ciphers 'EECDH+AESGCM:EDH+AESGCM:ECDHE-RSA-AES128-GCM-SHA256:AES256+EECDH:DHE-RSA-AES128-GCM-SHA256:AES256+EDH:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA:ECDHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256:DHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES256-GCM-SHA384:AES128-GCM-SHA256:AES256-SHA256:AES128-SHA256:AES256-SHA:AES128-SHA:DES-CBC3-SHA:HIGH:!aNULL:!eNULL:!EXPORT:!DES:!MD5:!PSK:!RC4';
+  ssl_dhparam /etc/nginx/ssl/dhsecure.pem;
+  add_header Strict-Transport-Security "max-age=31536000; includeSubdomains;";
+}
+
+#
+# redirect from other domains
+#
 server {
   listen 80;
   listen 443 ssl;
-  server_name www.subvisual.co;
+  server_name
+	www.subvisual.co
+	subvisual.pt
+        www.subvisual.pt
+        subvisual.info
+        www.subvisual.info
+        ;
+
   return 301 https://subvisual.co$request_uri;
 
   ssl_certificate     /etc/nginx/ssl/subvisual.co-2016/SSL.crt;
   ssl_certificate_key /etc/nginx/ssl/subvisual.co-2016/server.key;
-  ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
-  ssl_prefer_server_ciphers on;
-  ssl_session_cache shared:SSL:10m;
-  ssl_ciphers 'EECDH+AESGCM:EDH+AESGCM:ECDHE-RSA-AES128-GCM-SHA256:AES256+EECDH:DHE-RSA-AES128-GCM-SHA256:AES256+EDH:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA:ECDHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256:DHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES256-GCM-SHA384:AES128-GCM-SHA256:AES256-SHA256:AES128-SHA256:AES256-SHA:AES128-SHA:DES-CBC3-SHA:HIGH:!aNULL:!eNULL:!EXPORT:!DES:!MD5:!PSK:!RC4';
-  ssl_dhparam /etc/nginx/ssl/dhsecure.pem;
-  add_header Strict-Transport-Security "max-age=31536000; includeSubdomains;";
-}
-
-# http to https redirect
-server {
-  listen 80;
-  server_name subvisual.co subvisual.pt subvisual.info;
-  return 301 https://subvisual.co$request_uri;
-}
-
-# groupbuddies redirect
-server {
-  listen 80;
-  listen 443;
-  server_name groupbuddies.com www.groupbuddies.com;
-  return 301 https://subvisual.co$request_uri;
-
-  ssl_certificate     /etc/nginx/ssl/groupbuddies.com/SSL.crt;
-  ssl_certificate_key /etc/nginx/ssl/groupbuddies.com/server.key;
   ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
   ssl_prefer_server_ciphers on;
   ssl_session_cache shared:SSL:10m;

--- a/nginx/test.subvisual.co.conf
+++ b/nginx/test.subvisual.co.conf
@@ -1,6 +1,11 @@
+#
+# main server
+# nothing else is needed since this is for internal use only
+#
 server {
   listen 443;
   server_name test.subvisual.co;
+
   root /apps/test.subvisual.co/current;
 
   error_page 404 = /404/;
@@ -26,28 +31,4 @@ server {
   ssl_ciphers 'ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA:ECDHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256:DHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES256-GCM-SHA384:AES128-GCM-SHA256:AES256-SHA256:AES128-SHA256:AES256-SHA:AES128-SHA:DES-CBC3-SHA:HIGH:!aNULL:!eNULL:!EXPORT:!DES:!MD5:!PSK:!RC4';
   ssl_dhparam /etc/nginx/ssl/dhsecure.pem;
   add_header Strict-Transport-Security "max-age=31536000; includeSubdomains;";
-}
-
-# www redirect
-# groupbuddies redirect
-server {
-  listen 80;
-  listen 443 ssl;
-  server_name www.test.subvisual.co;
-  return 301 https://test.subvisual.co$request_uri;
-
-  ssl_certificate     /etc/nginx/ssl/subvisual.co/SSL.crt;
-  ssl_certificate_key /etc/nginx/ssl/subvisual.co/server.key;
-  ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
-  ssl_prefer_server_ciphers on;
-  ssl_ciphers 'ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA:ECDHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256:DHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES256-GCM-SHA384:AES128-GCM-SHA256:AES256-SHA256:AES128-SHA256:AES256-SHA:AES128-SHA:DES-CBC3-SHA:HIGH:!aNULL:!eNULL:!EXPORT:!DES:!MD5:!PSK:!RC4';
-  ssl_dhparam /etc/nginx/ssl/dhsecure.pem;
-  add_header Strict-Transport-Security "max-age=31536000; includeSubdomains;";
-}
-
-# http to https redirect
-server {
-  listen 80;
-  server_name test.subvisual.co;
-  return 301 https://$server_name$request_uri;
 }


### PR DESCRIPTION
These will soon be removed after migrating to S3, but I need to refactor some things to make the transition easier

- Removes nginx config file from the source directory. They had no business being there in the first place
- Separates `groupbuddies.com` rules into it's own file.
- Updates SSL config on blog, to match the main site
- Simplifies some of the other domains, such as `test.subvisual.co` which doesn't need any fancy stuff such as www-redirecting, given that it is for internal use only

PS: These are already being used in production, and working properly (apparently)