### PR TITLE
Remove Small Chat

### DIFF
--- a/source/layouts/layout.slim
+++ b/source/layouts/layout.slim
@@ -70,4 +70,3 @@ html.Theme itemscope='' itemtype='http://schema.org/WebPage' lang=data.site.lang
         j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
         })(window,document,'script','dataLayer','GTM-TTR9JW');
-      script src="https://embed.small.chat/T024F5AHHG54AZHXAS.js" async=true


### PR DESCRIPTION
Why:

* Big-ass dependency with little use. We're better off.