### PR TITLE
Fix community meetups section

### DIFF
--- a/source/partials/community/_events.slim
+++ b/source/partials/community/_events.slim
@@ -43,7 +43,7 @@
         .GridCell-content.StickToBottom.u-defaultThenLargeMargin
           .u-defaultThenLargeMargin
           .ContentFormatter.ContentFormatter--centerHorizontallyThenLeft.u-smallThenDefaultMargin
-            = retina_tag "community/meetups/braga.design.png"
+            = retina_tag "community/meetups/braga.design.png", class: "MeetupLogo"
           .ContentFormatter.ContentFormatter--centerHorizontallyThenLeft.u-smallMargin
             h2.Heading
               | Design
@@ -61,7 +61,7 @@
         .GridCell-content.StickToBottom.u-defaultThenLargeMargin
           .u-defaultThenLargeMargin
           .ContentFormatter.ContentFormatter--centerHorizontallyThenLeft.u-smallThenDefaultMargin
-            = retina_tag "community/meetups/braga.js.png"
+            = retina_tag "community/meetups/braga.js.png", class: "MeetupLogo"
           .ContentFormatter.ContentFormatter--centerHorizontallyThenLeft.u-smallMargin
             h2.Heading
               | JavaScript
@@ -79,7 +79,7 @@
         .GridCell-content.StickToBottom.u-defaultThenLargeMargin
           .u-defaultThenLargeMargin
           .ContentFormatter.ContentFormatter--centerHorizontallyThenLeft.u-smallThenDefaultMargin
-            = retina_tag "community/meetups/braga.product.png"
+            = retina_tag "community/meetups/braga.product.png", class: "MeetupLogo"
           .ContentFormatter.ContentFormatter--centerHorizontallyThenLeft.u-smallMargin
             h2.Heading
               | Product

--- a/source/stylesheets/components/_base.scss
+++ b/source/stylesheets/components/_base.scss
@@ -10,6 +10,7 @@
 @import 'experience';
 @import 'hire_us_grid';
 @import 'input_text';
+@import 'meetup_logo';
 @import 'numbered_steps';
 @import 'panel';
 @import 'section_heading';

--- a/source/stylesheets/components/_meetup_logo.scss
+++ b/source/stylesheets/components/_meetup_logo.scss
@@ -1,0 +1,3 @@
+.MeetupLogo {
+  max-width: 266px;
+}


### PR DESCRIPTION
Why:

* While the logo image is visually kept with the correct dimensions, for
  some reason Firefox on higher DPI screens assumes a larger width for
  it, pushing the grid cells beyond their limits, overflowing the whole
  website horizontally.

This change addresses the issue by:

+ Adding a new specific component just for the Meetup logos containing
  them to the correct dimensions.