### PR TITLE
Remove ID and secret from s3_website config

### DIFF
--- a/s3_website.yml
+++ b/s3_website.yml
@@ -1,7 +1,5 @@
-s3_id: <%= ENV["AWS_ACCESS_KEY"] %>
-s3_secret: <%= ENV["AWS_ACCESS_SECRET"] %>
-s3_bucket: subvisual.co
 cloudfront_distribution_id: EKUQ3N076J3QQ
+s3_bucket: subvisual.co
 s3_endpoint: eu-west-1
 
 site: build


### PR DESCRIPTION
Why:

* The current configuration forces the use of environment variables;
* Omitting the ID and secret will cause the gem to default to looking
  for the credentials in the AWS SDK default locations, thus allowing
  the use of user-wide credentials and environment variables alike.

  - [s3_website
  README](https://github.com/laurilehmijoki/s3_website#using-standard-aws-credentials)
  - [AWS SDK credentials
  locations](https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html)