### PR TITLE
Update Sprockets version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gem 'builder' # XML Builder
 gem 'dotenv', '~> 1.0.0'
 gem 'middleman', '~>3.3.12'
 gem 'middleman-autoprefixer'
-gem 'middleman-es6', github: 'vast/middleman-es6'
+gem 'middleman-es6', git: 'https://github.com/vast/middleman-es6.git'
 gem 'middleman-imageoptim'
 gem 'middleman-livereload', '~> 3.4.6'
 gem 'middleman-robots'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: git://github.com/vast/middleman-es6.git
+  remote: https://github.com/vast/middleman-es6.git
   revision: b7964bd199457e930251d9ad3ce00ea6ad70b8d7
   specs:
     middleman-es6 (0.1.0)
@@ -137,7 +137,7 @@ GEM
       sprockets-helpers (~> 1.1.0)
       sprockets-sass (~> 1.3.0)
     minitest (5.10.1)
-    multi_json (1.12.1)
+    multi_json (1.13.1)
     padrino-helpers (0.12.8.1)
       i18n (~> 0.6, >= 0.6.7)
       padrino-support (= 0.12.8.1)
@@ -149,7 +149,7 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
-    rack (1.6.5)
+    rack (1.6.10)
     rack-livereload (0.3.16)
       rack
     rack-test (0.6.3)
@@ -172,7 +172,7 @@ GEM
       temple (~> 0.7.6)
       tilt (>= 1.3.3, < 2.1)
     slop (3.6.0)
-    sprockets (2.12.4)
+    sprockets (2.12.5)
       hike (~> 1.2)
       multi_json (~> 1.0)
       rack (~> 1.0)
@@ -222,4 +222,4 @@ DEPENDENCIES
   therubyracer
 
 BUNDLED WITH
-   1.13.6
+   1.16.2


### PR DESCRIPTION
Why:

* Security vulnerability ([CVE-2018-3760](https://groups.google.com/forum/#!topic/ruby-security-ann/2S9Pwz2i16k)).

  ¯\_(ツ)_/¯

Also:

* Using `github` to fetch gems directly from the repository is not safe,
  so I changed `middleman-es6` to use HTTPS instead.